### PR TITLE
change open to URI.open to fix deprecation warning

### DIFF
--- a/lib/xcal/xcal.rb
+++ b/lib/xcal/xcal.rb
@@ -46,7 +46,7 @@ class Xcal::Xcal
 
   def fetch_holidays_from_remote_ics(ics_url)
     holidays = {}
-    ical = open(ics_url){|f| f.read}
+    ical = URI.open(ics_url){|f| f.read}
     cals = Icalendar::Calendar.parse(ical)
     cals.each{|cal|
       cal.events.each{|event|


### PR DESCRIPTION
To fix the following warning with ruby 2.7.2
```
warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open
```